### PR TITLE
feat(agent): LangGraph minimal (RAG + reply), CLI chat, tests

### DIFF
--- a/app/agent_graph.py
+++ b/app/agent_graph.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, TypedDict
+
+from langgraph.graph import StateGraph, END
+
+from app.rag import retrieve_snippets
+from app.reply import build_context, suggest_reply
+from app.routing import classify_email
+from app.ingest import Email
+
+
+# ------------------ État de l'agent ------------------
+
+class AgentState(TypedDict, total=False):
+    query: str
+    snippets: List[Dict[str, str]]
+    email: Optional[Email]
+    reply_text: Optional[str]      # réponse formatée (si e-mail présent)
+    final_text: Optional[str]      # fallback quand pas d’e-mail
+
+
+# ------------------ Nœuds (fonctions pures) ------------------
+
+def node_retrieve(state: AgentState, kb_dir: str = "data/kb", persist_dir: str = "data/chroma") -> AgentState:
+    q = state.get("query") or ""
+    snips = retrieve_snippets(q, k=3, kb_dir=kb_dir, persist_dir=persist_dir)
+    state["snippets"] = snips
+    return state
+
+
+def node_reply(state: AgentState, kb_dir: str = "data/kb", persist_dir: str = "data/chroma") -> AgentState:
+    """
+    Si un e-mail est chargé, on produit une réponse formatée via notre module reply.
+    """
+    email = state.get("email")
+    snips = state.get("snippets") or []
+    if email:
+        routing = classify_email(email)
+        ctx = build_context(email, routing_decision=routing, snippets=snips)
+        state["reply_text"] = suggest_reply(email, ctx)
+    return state
+
+
+def node_format_without_email(state: AgentState) -> AgentState:
+    """
+    Si aucun e-mail n'est chargé, on renvoie un texte simple basé sur les snippets.
+    """
+    snips = state.get("snippets") or []
+    if not snips:
+        state["final_text"] = "Je n'ai trouvé aucune information pertinente dans la base."
+        return state
+
+    # Construire une réponse compacte avec citations
+    lines = ["Voici des éléments de réponse basés sur la documentation :", ""]
+    # Extraire jusqu'à 3 lignes commençant par '1. ', '2. ' etc. si disponibles
+    steps: List[str] = []
+    for sn in snips:
+        for line in sn["content"].splitlines():
+            if line.strip().startswith(("1.", "2.", "3.", "4.")):
+                steps.append(line.strip())
+            if len(steps) >= 4:
+                break
+        if len(steps) >= 4:
+            break
+    if steps:
+        lines += steps
+        lines.append("")
+
+    # Bloc sources
+    from pathlib import Path
+    seen = set()
+    src_lines = []
+    for sn in snips:
+        name = Path(sn.get("source", "")).name
+        if name and name not in seen:
+            seen.add(name)
+            src_lines.append(f"- {name}")
+    if src_lines:
+        lines.append("Sources:")
+        lines += src_lines
+
+    lines.append("\nCordialement,\nL'équipe Support")
+    state["final_text"] = "\n".join(lines)
+    return state
+
+
+# ------------------ Construction du graphe ------------------
+
+def build_graph():
+    """
+    Graphe minimal :
+    START -> retrieve -> [si email] reply -> END
+                       -> [sinon] format_without_email -> END
+    """
+    g = StateGraph(AgentState)
+
+    # Enregistrer les nœuds
+    g.add_node("retrieve", node_retrieve)
+    g.add_node("reply", node_reply)
+    g.add_node("format_without_email", node_format_without_email)
+
+    # Flux : START -> retrieve
+    g.set_entry_point("retrieve")
+
+    # Branches conditionnelles après retrieve
+    def branch_on_email(state: AgentState):
+        return "has_email" if state.get("email") is not None else "no_email"
+
+    g.add_conditional_edges(
+        "retrieve",
+        branch_on_email,
+        {
+            "has_email": "reply",
+            "no_email": "format_without_email",
+        },
+    )
+    # Sorties
+    g.add_edge("reply", END)
+    g.add_edge("format_without_email", END)
+
+    return g.compile()
+
+
+# ------------------ API utilitaire pour la CLI/tests ------------------
+
+def run_turn(graph, query: str, email_obj: Optional[Email], kb_dir: str = "data/kb", persist_dir: str = "data/chroma") -> str:
+    """
+    Lance un tour de conversation : prend une requête + (optionnel) un e-mail.
+    Retourne un texte final (réponse formatée si e-mail, sinon synthèse + sources).
+    """
+    state: AgentState = {"query": query, "email": email_obj}
+    # On peut passer des kwargs aux nœuds via .invoke(input, config={'configurable': {...}})
+    out_state: AgentState = graph.invoke(
+        state,
+        config={"configurable": {"kb_dir": kb_dir, "persist_dir": persist_dir}},
+    )
+
+    # Selon le chemin emprunté, 'reply_text' ou 'final_text' sera rempli
+    if out_state.get("reply_text"):
+        return out_state["reply_text"]
+    if out_state.get("final_text"):
+        return out_state["final_text"]
+    # Cas inattendu : on renvoie un message neutre
+    return "Je n'ai pas pu générer de réponse."

--- a/main.py
+++ b/main.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+import click
+from pathlib import Path
+from typing import Optional
+
+from app.ingest import parse_email_file
+from app.agent_graph import build_graph, run_turn
+from app.rag import build_index
+
+
+@click.group()
+def cli():
+    """Support Mail Assistant (CLI)"""
+    pass
+
+
+@cli.command()
+def hello():
+    """Commande de test simple."""
+    click.echo("Hello from support_mail_assistant 👋")
+
+
+@cli.command()
+@click.option("--kb-dir", default="data/kb", show_default=True, help="Répertoire des fichiers .md")
+@click.option("--persist-dir", default="data/chroma", show_default=True, help="Répertoire de l'index Chroma (persistant)")
+def chat(kb_dir: str, persist_dir: str):
+    """
+    Démarre un mini-chat local :
+      - /load <path.eml|.txt> : charge un e-mail pour contextualiser les réponses
+      - /clear : efface l'e-mail chargé
+      - /exit : quitter
+      - tout autre texte : question / requête
+    """
+    # Construire (ou reconstruire) l'index au démarrage
+    build_index(kb_dir=kb_dir, persist_dir=persist_dir)
+    graph = build_graph()
+    loaded_email = None
+    click.echo("=== Chat Support (local) ===")
+    click.echo("Commandes: /load <fichier>, /clear, /exit")
+    while True:
+        try:
+            msg = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            click.echo("\nBye.")
+            break
+        if not msg:
+            continue
+        if msg.lower() in {"/exit", "exit", "quit", ":q"}:
+            click.echo("Bye.")
+            break
+        if msg.startswith("/load "):
+            path = msg.split(" ", 1)[1].strip()
+            p = Path(path)
+            if not p.exists():
+                click.echo(f"[!] Fichier introuvable: {p}")
+                continue
+            try:
+                loaded_email = parse_email_file(p)
+                click.echo(f"[ok] E-mail chargé: {p.name}")
+            except Exception as e:
+                click.echo(f"[!] Erreur parsing: {e}")
+            continue
+        if msg == "/clear":
+            loaded_email = None
+            click.echo("[ok] Contexte e-mail effacé.")
+            continue
+
+        # Exécuter un tour d'agent
+        try:
+            out = run_turn(graph, msg, email_obj=loaded_email, kb_dir=kb_dir, persist_dir=persist_dir)
+            click.echo(out)
+        except Exception as e:
+            click.echo(f"[!] Erreur agent: {e}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ chromadb==0.5.11
 langchain>=0.3,<0.4
 langchain-community>=0.3,<0.4
 fastembed>=0.7,<0.8
+
+
+# --- Agent / Orchestration ---
+langgraph>=0.2,<0.4

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from app.ingest import parse_email_file
+from app.routing import classify_email
+from app.rag import build_index
+from app.agent_graph import build_graph, run_turn
+
+def test_agent_reply_with_email(tmp_path):
+    # Index KB dans un répertoire temporaire
+    build_index(kb_dir="data/kb", persist_dir=str(tmp_path))
+    # E-mail d'incident
+    email = parse_email_file(Path("data/emails/sample_incident.eml"))
+    g = build_graph()
+    out = run_turn(g, "erreur 502 sur la connexion", email_obj=email, kb_dir="data/kb", persist_dir=str(tmp_path))
+    assert "Sources:" in out
+    assert "incident_502.md" in out
+    assert "Objet: RE:" in out  # on a formaté une réponse pour l'e-mail
+
+def test_agent_answer_without_email(tmp_path):
+    build_index(kb_dir="data/kb", persist_dir=str(tmp_path))
+    g = build_graph()
+    out = run_turn(g, "réinitialiser mot de passe oublié", email_obj=None, kb_dir="data/kb", persist_dir=str(tmp_path))
+    assert "Sources:" in out
+    assert "reset_mot_de_passe.md" in out


### PR DESCRIPTION
- Ajout app/agent_graph.py (retrieve → reply/synthèse).
- CLI python main.py chat (charges un .eml avec /load …).
- Tests tests/test_agent.py.
- Dépendance langgraph ajoutée.